### PR TITLE
Add the Linebender CI script and conform the codebase to it.

### DIFF
--- a/.github/copyright.sh
+++ b/.github/copyright.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# If there are new files with headers that can't match the conditions here,
+# then the files can be ignored by an additional glob argument via the -g flag.
+# For example:
+#   -g "!src/special_file.rs"
+#   -g "!src/special_directory"
+
+# Check all the standard Rust source files
+output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Kompari Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" .)
+
+if [ -n "$output" ]; then
+	echo -e "The following files lack the correct copyright header:\n"
+	echo $output
+	echo -e "\n\nPlease add the following header:\n"
+	echo "// Copyright $(date +%Y) the Kompari Authors"
+	echo "// SPDX-License-Identifier: Apache-2.0 OR MIT"
+	echo -e "\n... rest of the file ...\n"
+	exit 1
+fi
+
+echo "All files have correct copyright headers."
+exit 0

--- a/.github/debug_assertions.sh
+++ b/.github/debug_assertions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check all the standard Rust source files
+output=$(rg "debug_assertions" -g "*.rs" .)
+
+if [ -z "$output" ]; then
+	if [ "$USING_DEBUG_ASSERTIONS" = "true" ]; then
+		echo "Could not find any debug_assertions usage in Rust code."
+		echo "The CI script must be modified to not expect usage."
+		echo "Set USING_DEBUG_ASSERTIONS to false in .github/workflows/ci.yml."
+		exit 1
+	else
+		echo "Expected no debug_assertions usage in Rust code and found none."
+		exit 0
+	fi
+else
+	if [ "$USING_DEBUG_ASSERTIONS" = "true" ]; then
+		echo "Expected debug_assertions to be used in Rust code and found it."
+		exit 0
+	else
+		echo "Found debug_assertions usage in Rust code."
+		echo ""
+		echo $output
+		echo ""
+		echo "The CI script must be modified to expect this usage."
+		echo "Set USING_DEBUG_ASSERTIONS to true in .github/workflows/ci.yml."
+		exit 1
+	fi
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,320 @@
+env:
+  # We aim to always test with the latest stable Rust toolchain, however we pin to a specific
+  # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
+  # come automatically. If the version specified here is no longer the latest stable version,
+  # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
+  RUST_STABLE_VER: "1.83" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  # The purpose of checking with the minimum supported Rust toolchain is to detect its staleness.
+  # If the compilation fails, then the version specified here needs to be bumped up to reality.
+  # Be sure to also update the rust-version property in the workspace Cargo.toml file,
+  # plus all the README.md files of the affected packages.
+  RUST_MIN_VER: "1.83"
+  # List of packages that can not target Wasm.
+  NO_WASM_PKGS: ""
+  # List of packages that will be checked with the minimum supported Rust version.
+  # This should be limited to packages that are intended for publishing.
+  RUST_MIN_VER_PKGS: "-p kompari"
+  # Whether the workspace contains Rust code using the debug_assertions configuration option.
+  USING_DEBUG_ASSERTIONS: "false"
+
+
+# Rationale
+#
+# We don't run clippy with --all-targets because then even --lib and --bins are compiled with
+# dev dependencies enabled, which does not match how they would be compiled by users.
+# A dev dependency might enable a feature that we need for a regular dependency,
+# and checking with --all-targets would not find our feature requirements lacking.
+# This problem still applies to cargo resolver version 2.
+# Thus we split all the targets into two steps, one with --lib --bins
+# and another with --tests --benches --examples.
+# Also, we can't give --lib --bins explicitly because then cargo will error on binary-only packages.
+# Luckily the default behavior of cargo with no explicit targets is the same but without the error.
+#
+# We use cargo-hack for a similar reason. Cargo's --workspace will do feature unification across
+# the whole workspace. While cargo-hack will instead check each workspace package separately.
+#
+# Using cargo-hack also allows us to more easily test the feature matrix of our packages.
+# We use --each-feature & --optional-deps which will run a separate check for every feature.
+#
+# We use cargo-nextest, which has a faster concurrency model for running tests.
+# However cargo-nextest does not support running doc tests, so we also have a cargo test --doc step.
+# For more information see https://github.com/nextest-rs/nextest/issues/16
+#
+# The MSRV jobs run only cargo check because different clippy versions can disagree on goals and
+# running tests introduces dev dependencies which may require a higher MSRV than the bare package.
+#
+# If the workspace uses debug_assertions then we verify code twice, with it set to true or false.
+# We always keep it true for external dependencies so that we can reuse the cache for faster builds.
+#
+# We don't save caches in the merge-group cases, because those caches will never be re-used (apart
+# from the very rare cases where there are multiple PRs in the merge queue).
+# This is because GitHub doesn't share caches between merge queues and the main branch.
+
+name: CI
+
+on:
+  pull_request:
+  merge_group:
+  # We run on push, even though the commit is the same as when we ran in merge_group.
+  # This allows the cache to be primed.
+  # See https://github.com/orgs/community/discussions/66430
+  push:
+    branches:
+      - main
+
+jobs:
+  fmt:
+    name: formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: rustfmt
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
+      - name: install ripgrep
+        run: |
+          sudo apt update
+          sudo apt install ripgrep
+
+      - name: check copyright headers
+        run: bash .github/copyright.sh
+
+      - name: check debug_assertions presence
+        run: bash .github/debug_assertions.sh
+
+  clippy-stable:
+    name: cargo clippy
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          components: clippy
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo clippy
+        run: cargo hack clippy --workspace --locked --profile ci --optional-deps --each-feature -- -D warnings
+
+      - name: cargo clippy (auxiliary)
+        run: cargo hack clippy --workspace --locked --profile ci --optional-deps --each-feature --tests --benches --examples -- -D warnings
+
+      - name: cargo clippy (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack clippy --workspace --locked --profile ci --optional-deps --each-feature -- -D warnings
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+      - name: cargo clippy (auxiliary) (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack clippy --workspace --locked --profile ci --optional-deps --each-feature --tests --benches --examples -- -D warnings
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+  clippy-stable-wasm:
+    name: cargo clippy (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo clippy
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature -- -D warnings
+
+      - name: cargo clippy (auxiliary)
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature --tests --benches --examples -- -D warnings
+
+      - name: cargo clippy (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature -- -D warnings
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+      - name: cargo clippy (auxiliary) (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack clippy --workspace ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature --tests --benches --examples -- -D warnings
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+  test-stable:
+    name: cargo test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo nextest
+        run: cargo nextest run --workspace --locked --all-features --no-fail-fast
+
+      - name: cargo test --doc
+        run: cargo test --doc --workspace --locked --all-features --no-fail-fast
+
+  test-stable-wasm:
+    name: cargo test (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      # TODO: Find a way to make tests work. Until then the tests are merely compiled.
+      - name: cargo test compile
+        run: cargo test --workspace ${{ env.NO_WASM_PKGS }} --locked --target wasm32-unknown-unknown --all-features --no-run
+
+  check-msrv:
+    name: cargo check (msrv)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install msrv toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MIN_VER }}
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo check
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --profile ci --optional-deps --each-feature
+
+      - name: cargo check (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --profile ci --optional-deps --each-feature
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+  check-msrv-wasm:
+    name: cargo check (msrv) (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install msrv toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_MIN_VER }}
+          targets: wasm32-unknown-unknown
+
+      - name: install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo check
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature
+
+      - name: cargo check (no debug_assertions)
+        if: env.USING_DEBUG_ASSERTIONS == 'true'
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} ${{ env.NO_WASM_PKGS }} --locked --profile ci --target wasm32-unknown-unknown --optional-deps --each-feature
+        env:
+          CARGO_PROFILE_CI_DEBUG_ASSERTIONS: "false"
+
+  doc:
+    name: cargo doc
+    # NOTE: We don't have any platform specific docs in this workspace, so we only run on Ubuntu.
+    #       If we get per-platform docs (win/macos/linux/wasm32/..) then doc jobs should match that.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      # We test documentation using nightly to match docs.rs.
+      - name: cargo doc
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs -D warnings'
+
+  # If this fails, consider changing your text or adding something to .typos.toml.
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check typos
+        uses: crate-ci/typos@v1.27.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 report.html
-.*

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,22 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+extend-exclude = [
+    # /.git isn't in .gitignore, because git never tracks it.
+    # Typos doesn't know that, though.
+    "/.git",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "kompari"
 version = "0.1.0"
 edition = "2021"
 
-license = "MIT"
+license = "Apache-2.0 OR MIT"
 description = "Reporting tool of image differences for snaphost testing"
 repository = "https://github.com/linebender/kompari"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 license = "MIT"
 description = "Reporting tool of image differences for snaphost testing"
-repository = "https://github.com/spirali/image_diff_review"
+repository = "https://github.com/linebender/kompari"
 readme = "README.md"
 keywords = ["image", "report", "diff", "tests"]
 
@@ -30,3 +30,8 @@ cli = ["clap"]
 [[bin]]
 name = "kompari"
 required-features = ["cli"]
+
+[profile.ci]
+inherits = "dev"
+[profile.ci.package."*"]
+debug-assertions = true # Keep always on for dependencies for cache reuse.

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ It can be used as a stand-alone CLI tool or as a Rust crate.
 Basic installation, `PNG` format only
 
 ```commandline
-$ cargo install image_diff_review --features=cli
+$ cargo install kompari --features=cli
 ```
 
 OR with all supported formats
 
 ```commandline
-$ cargo install image_diff_review --features=cli,all-formats
+$ cargo install kompari --features=cli,all-formats
 ```
 
 ### Usage
 
 ```commandline
-$ image_diff_review <left/image_dir> <right/image_dir> report
+$ kompari <left/image_dir> <right/image_dir> report
 ```
 
 ## License

--- a/src/bin/kompari.rs
+++ b/src/bin/kompari.rs
@@ -1,5 +1,8 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use clap::Parser;
-use image_diff_review::{CompareConfig, ImageDiff, ReportConfig};
+use kompari::{CompareConfig, ImageDiff, ReportConfig};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -47,7 +50,7 @@ enum Command {
     Report(ReportArgs),
 }
 
-fn process_command(args: Args) -> image_diff_review::Result<()> {
+fn process_command(args: Args) -> kompari::Result<()> {
     let mut config = CompareConfig::default();
     config.set_ignore_match(args.ignore_match);
     config.set_ignore_left_missing(args.ignore_left_missing);

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::difference::ImageInfoResult::Loaded;
 use crate::pair::Pair;
 use image::{Pixel, Rgb, RgbImage};

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::difference::{compute_differences, Difference, ImageInfoResult, PairResult};
 use image::ImageError;
 use std::path::{Path, PathBuf};
@@ -51,7 +54,7 @@ pub struct ReportConfig<'a> {
     right_title: &'a str,
 }
 
-impl<'a> Default for ReportConfig<'a> {
+impl Default for ReportConfig<'_> {
     fn default() -> Self {
         ReportConfig {
             left_title: "Left image",
@@ -116,4 +119,12 @@ impl ImageDiff {
         }
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    // CI will fail unless cargo nextest can execute at least one test per workspace.
+    // Delete this dummy test once we have an actual real test.
+    #[test]
+    fn dummy_test_until_we_have_a_real_test() {}
 }

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::fs::read_images_from_dir;
 use std::path::{Path, PathBuf};
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::difference::{Difference, ImageInfoResult, PairResult, Size};
 use crate::ReportConfig;
 use base64::prelude::*;


### PR DESCRIPTION
This is based on the latest Linebender CI standard which can be best seen in the [Xilem repo](https://github.com/linebender/xilem/tree/main/.github) although Xilem does have some extra GPU and snapshot testing parts that were removed here.

The Wasm checks pass so I left it in, although I'm not fully sure if targeting Wasm is really part of the plan here.

The `.gitignore` file had an entry for `.*` which is too broad. If there are actual files which still need to be ignored then a more precise filter can be added in a follow-up PR.

The MSRV in this PR is the same as stable on purpose to keep things focused on the CI. Finding the actual MSRV and adding the various readme parts etc related to it are follow-up work.