### PR TITLE
Added xtask-cli to simplify xtasks that uses kompari

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "fdeflate"
-version = "0.3.7"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
 dependencies = [
  "simd-adler32",
 ]
@@ -254,22 +254,8 @@ checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
- "image-webp",
  "num-traits",
  "png",
- "tiff",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e031e8e3d94711a9ccb5d6ea357439ef3dcbed361798bd4071dc4d9793fbe22f"
-dependencies = [
- "byteorder-lite",
- "quick-error",
 ]
 
 [[package]]
@@ -283,12 +269,6 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -373,9 +353,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "png"
-version = "0.17.15"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -415,12 +395,6 @@ checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -478,17 +452,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -562,12 +525,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
-
-[[package]]
-name = "weezl"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "windows-core"
@@ -650,18 +607,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
-dependencies = [
- "zune-core",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,8 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["png"]
-all-formats = ["png", "jpeg", "webp", "bmp", "tiff"]
-png = ["image/png"]
-bmp = ["image/bmp"]
-tiff = ["image/tiff"]
-jpeg = ["image/jpeg"]
-webp = ["image/webp"]
 cli = ["dep:clap"]
+xtask-cli = ["dep:clap"]
 
 [[bin]]
 name = "kompari"
@@ -34,7 +28,7 @@ required-features = ["cli"]
 [dependencies]
 base64 = "0.22"
 chrono = "0.4"
-image = { version = "0.25", default-features = false }
+image = { version = "0.25", default-features = false, features = ["png"] }
 maud = "0.26"
 thiserror = "2"
 clap = { version = "4.5", features = ["derive"], optional = true }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,23 +1,33 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::ffi::OsString;
-use std::path::Path;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 
-pub fn read_images_from_dir(path: &Path) -> crate::Result<Vec<OsString>> {
-    Ok(std::fs::read_dir(path)?
-        .flatten()
-        .filter_map(|path| {
+pub(crate) fn list_image_dir(
+    dir_path: &Path,
+) -> Result<impl Iterator<Item = PathBuf>, std::io::Error> {
+    Ok(std::fs::read_dir(dir_path)?.filter_map(|entry| {
+        if let Ok(entry) = entry {
+            let path = entry.path();
             if path
-                .path()
                 .extension()
-                .and_then(|p| p.to_str())
-                .map_or(false, |p| p.to_ascii_lowercase() == "png")
+                .and_then(OsStr::to_str)
+                .map(|ext| ext.to_ascii_lowercase() == "png")
+                .unwrap_or(false)
             {
-                Some(path.file_name())
+                Some(path)
             } else {
                 None
             }
-        })
-        .collect())
+        } else {
+            None
+        }
+    }))
+}
+
+pub(crate) fn list_image_dir_names(
+    dir_path: &Path,
+) -> Result<impl Iterator<Item = OsString>, std::io::Error> {
+    Ok(list_image_dir(dir_path)?.filter_map(|p| p.file_name().map(|name| name.to_os_string())))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,7 @@ mod pair;
 mod report;
 
 #[cfg(feature = "xtask-cli")]
-mod xtask_cli;
-
-#[cfg(feature = "xtask-cli")]
-pub use xtask_cli::{xtask_cli, XtaskActions};
+pub mod xtask_cli;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,12 @@ mod fs;
 mod pair;
 mod report;
 
+#[cfg(feature = "xtask-cli")]
+mod xtask_cli;
+
+#[cfg(feature = "xtask-cli")]
+pub use xtask_cli::{xtask_cli, XtaskActions};
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("IO error")]

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::fs::read_images_from_dir;
+use crate::fs::list_image_dir_names;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -24,8 +24,8 @@ pub(crate) fn pairs_from_paths(left_path: &Path, right_path: &Path) -> crate::Re
     if !right_path.is_dir() {
         return Err(crate::Error::NotDirectory(right_path.to_path_buf()));
     }
-    let mut names = read_images_from_dir(left_path)?;
-    names.append(&mut read_images_from_dir(right_path)?);
+    let mut names: Vec<_> = list_image_dir_names(left_path)?.collect();
+    names.extend(list_image_dir_names(right_path)?);
     names.sort_unstable();
     names.dedup();
     Ok(names

--- a/src/xtask_cli.rs
+++ b/src/xtask_cli.rs
@@ -1,0 +1,126 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::fs::{list_image_dir, list_image_dir_names};
+use clap::Parser;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct XtaskArgs {
+    #[clap(subcommand)]
+    command: XtaskCommand,
+}
+
+#[derive(Parser, Debug)]
+enum XtaskCommand {
+    Report(ReportArgs),
+    Clean,
+    DeadSnapshots(DeadSnapshotArgs),
+}
+
+#[derive(Parser, Debug)]
+struct ReportArgs {
+    /// Output filename, default 'report.html'
+    #[arg(long, default_value = "report.html")]
+    output: PathBuf,
+}
+
+#[derive(Parser, Debug)]
+struct DeadSnapshotArgs {
+    #[arg(long, default_value_t = false)]
+    remove_files: bool,
+}
+
+pub trait XtaskActions {
+    fn generate_all_tests(&self) -> crate::Result<()>;
+}
+
+fn clean_image_dir(path: &Path) -> crate::Result<()> {
+    for path in list_image_dir(path)? {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn find_dead_snapshots(
+    current_path: &Path,
+    snapshot_path: &Path,
+    actions: impl XtaskActions,
+) -> crate::Result<Vec<PathBuf>> {
+    clean_image_dir(current_path)?;
+    actions.generate_all_tests()?;
+    let current_images: BTreeSet<_> = list_image_dir_names(current_path)?.collect();
+    let snapshot_images: BTreeSet<_> = list_image_dir_names(snapshot_path)?.collect();
+    Ok(snapshot_images
+        .difference(&current_images)
+        .map(|name| current_path.join(name))
+        .collect())
+}
+
+fn process_dead_snapshots(
+    current_path: &Path,
+    snapshot_path: &Path,
+    actions: impl XtaskActions,
+    args: &DeadSnapshotArgs,
+) -> crate::Result<()> {
+    let dead_snapshots = find_dead_snapshots(current_path, snapshot_path, actions)?;
+    if dead_snapshots.is_empty() {
+        println!("No dead snapshots detected");
+    } else {
+        println!("========== DEAD SNAPSHOTS ==========");
+        for path in &dead_snapshots {
+            println!("{}", path.display());
+        }
+        println!("====================================");
+        if args.remove_files {
+            for path in &dead_snapshots {
+                std::fs::remove_file(path)?;
+            }
+            println!("Dead snapshots removed")
+        } else {
+            println!("Run the command with '--remove' to remove the files")
+        }
+    }
+    clean_image_dir(current_path)?;
+    Ok(())
+}
+
+fn create_report(
+    current_path: &Path,
+    snapshot_path: &Path,
+    report_args: &ReportArgs,
+) -> Result<(), crate::Error> {
+    let mut config = crate::CompareConfig::default();
+    config.set_ignore_left_missing(true);
+
+    let mut image_diff = crate::ImageDiff::default();
+    image_diff.compare_directories(&config, current_path, snapshot_path)?;
+
+    let mut report_config = crate::ReportConfig::default();
+    report_config.set_left_title("Current test");
+    report_config.set_right_title("Snapshot");
+    image_diff.create_report(&report_config, &report_args.output, true)?;
+    Ok(())
+}
+
+pub fn xtask_cli(
+    current_path: &Path,
+    snapshots_path: &Path,
+    actions: impl XtaskActions,
+) -> crate::Result<()> {
+    let args = XtaskArgs::parse();
+    match args.command {
+        XtaskCommand::Report(report_args) => {
+            create_report(current_path, snapshots_path, &report_args)?;
+        }
+        XtaskCommand::Clean => {
+            clean_image_dir(current_path)?;
+        }
+        XtaskCommand::DeadSnapshots(ds_args) => {
+            process_dead_snapshots(current_path, snapshots_path, actions, &ds_args)?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Added a common code useful for xtasks: clean test dir & detect dead snapshots; this allows to simplify code in xtests.