### PR TITLE
Fixed --filter & --embed-images option + tests

### DIFF
--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -83,6 +83,8 @@ fn main() -> kompari::Result<()> {
     let mut diff_config = DirDiffConfig::new(args.left_path, args.right_path);
     diff_config.set_ignore_left_missing(args.ignore_left_missing);
     diff_config.set_ignore_right_missing(args.ignore_right_missing);
+    diff_config.set_filter_name(args.filter);
+
     let mut report_config = kompari_html::ReportConfig::default();
     report_config.set_left_title(args.left_title);
     report_config.set_right_title(args.right_title);
@@ -90,8 +92,9 @@ fn main() -> kompari::Result<()> {
     match args.command {
         Command::Report(args) => {
             let diff = diff_config.create_diff()?;
-            let output = args.output;
+            report_config.set_embed_images(args.embed_images);
             let report = render_html_report(&report_config, diff.results())?;
+            let output = args.output;
             std::fs::write(&output, report)?;
             println!("Report written into '{}'", output.display());
         }

--- a/kompari-cli/tests/tests.rs
+++ b/kompari-cli/tests/tests.rs
@@ -29,4 +29,42 @@ fn test_create_report() {
         .map(|e| e.unwrap().file_name().to_str().unwrap().to_owned())
         .collect();
     assert_eq!(result, vec!["report.html"]);
+    let report = std::fs::read_to_string(workdir.path().join("report.html")).unwrap();
+    for name in [
+        "bright",
+        "changetext",
+        "right_missing",
+        "left_missing",
+        "shift",
+        "size_error",
+    ] {
+        assert!(report.contains(&format!("{}.png", name)));
+    }
+    assert!(!report.contains("same.png"));
+}
+
+#[test]
+fn test_filter_filenames() {
+    let workdir = TempDir::new().unwrap();
+    std::env::set_current_dir(workdir.path()).unwrap();
+
+    let test_dir = test_assets_dir();
+    let left = test_dir.join("left");
+    let right = test_dir.join("right");
+    let mut cmd = Command::cargo_bin("kompari-cli").unwrap();
+    cmd.arg("--filter").arg("change");
+    cmd.arg(&left).arg(&right).arg("report");
+    cmd.current_dir(&workdir);
+    cmd.assert().success();
+    let report = std::fs::read_to_string(workdir.path().join("report.html")).unwrap();
+    assert!(report.contains("changetext.png"));
+    for name in [
+        "bright",
+        "right_missing",
+        "left_missing",
+        "shift",
+        "size_error",
+    ] {
+        assert!(!report.contains(&format!("{}.png", name)));
+    }
 }


### PR DESCRIPTION
Fixes CLI problems forgotten when Kompari was restructured.