### PR TITLE
Detecting unoptimized snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "clap",
  "kompari",
  "kompari-html",
+ "kompari-tasks",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,8 +721,10 @@ name = "kompari-tasks"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "humansize",
  "kompari",
  "kompari-html",
+ "termcolor",
 ]
 
 [[package]]
@@ -739,6 +750,12 @@ checksum = "013344b17f9dceddff4872559ae19378bd8ee0479eccdd266d2dd2e894b4792f"
 dependencies = [
  "libdeflate-sys",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -1179,6 +1196,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -23,14 +23,24 @@ $ cargo install kompari --features=cli
 OR with all supported formats
 
 ```commandline
-$ cargo install kompari --features=cli,all-formats
+$ cargo install kompari --features=cli
 ```
 
 ### Usage
 
+
+Create static HTML report:
+
 ```commandline
-$ kompari <left/image_dir> <right/image_dir> report
+$ kompari report <left/image_dir> <right/image_dir>
 ```
+
+Start HTTP server for interactive test blessing:
+
+```commandline
+$ kompari review <left/image_dir> <right/image_dir>
+```
+
 
 ## Minimum supported Rust Version (MSRV)
 

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -503,6 +503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,8 +650,10 @@ name = "kompari-tasks"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "humansize",
  "kompari",
  "kompari-html",
+ "termcolor",
 ]
 
 [[package]]
@@ -668,6 +679,12 @@ checksum = "013344b17f9dceddff4872559ae19378bd8ee0479eccdd266d2dd2e894b4792f"
 dependencies = [
  "libdeflate-sys",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -1043,6 +1060,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "thiserror"

--- a/kompari-cli/Cargo.toml
+++ b/kompari-cli/Cargo.toml
@@ -15,6 +15,7 @@ repository.workspace = true
 kompari = { path = "../kompari" }
 kompari-html = { path = "../kompari-html" }
 clap = { workspace = true }
+kompari-tasks = { path = "../kompari-tasks" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/kompari-cli/tests/tests.rs
+++ b/kompari-cli/tests/tests.rs
@@ -21,7 +21,7 @@ fn test_create_report() {
     let left = test_dir.join("left");
     let right = test_dir.join("right");
     let mut cmd = Command::cargo_bin("kompari-cli").unwrap();
-    cmd.arg(&left).arg(&right).arg("report");
+    cmd.arg("report").arg(&left).arg(&right);
     cmd.current_dir(&workdir);
     cmd.assert().success();
     let result: Vec<_> = std::fs::read_dir(&workdir)
@@ -52,8 +52,8 @@ fn test_filter_filenames() {
     let left = test_dir.join("left");
     let right = test_dir.join("right");
     let mut cmd = Command::cargo_bin("kompari-cli").unwrap();
-    cmd.arg("--filter").arg("change");
-    cmd.arg(&left).arg(&right).arg("report");
+    cmd.arg("report").arg("--filter").arg("change");
+    cmd.arg(&left).arg(&right);
     cmd.current_dir(&workdir);
     cmd.assert().success();
     let report = std::fs::read_to_string(workdir.path().join("report.html")).unwrap();

--- a/kompari-tasks/Cargo.toml
+++ b/kompari-tasks/Cargo.toml
@@ -16,3 +16,5 @@ repository.workspace = true
 kompari = { path = "../kompari" }
 kompari-html = { path = "../kompari-html" }
 clap = { workspace = true }
+termcolor = "1.4"
+humansize = "2.1"

--- a/kompari-tasks/src/args.rs
+++ b/kompari-tasks/src/args.rs
@@ -17,6 +17,7 @@ pub enum Command {
     Review(ReviewArgs),
     Clean,
     DeadSnapshots(DeadSnapshotArgs),
+    SizeCheck(SizeCheckArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -41,4 +42,11 @@ pub struct ReviewArgs {
 pub struct DeadSnapshotArgs {
     #[arg(long, default_value_t = false)]
     pub remove_files: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct SizeCheckArgs {
+    /// If enabled, images on file system are replaced with optimized version
+    #[arg(long, default_value_t = false)]
+    pub optimize: bool,
 }

--- a/kompari-tasks/src/lib.rs
+++ b/kompari-tasks/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod args;
+mod output;
 mod task;
 
 pub use args::Args;

--- a/kompari-tasks/src/lib.rs
+++ b/kompari-tasks/src/lib.rs
@@ -12,8 +12,8 @@
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-mod args;
-mod output;
+pub mod args;
+pub mod output;
 mod task;
 
 pub use args::Args;

--- a/kompari-tasks/src/output.rs
+++ b/kompari-tasks/src/output.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use humansize::{format_size, DECIMAL};
 use kompari::OptimizationResult;
 use std::io::Write;

--- a/kompari-tasks/src/output.rs
+++ b/kompari-tasks/src/output.rs
@@ -1,0 +1,33 @@
+use humansize::{format_size, DECIMAL};
+use kompari::OptimizationResult;
+use std::io::Write;
+use termcolor::{Color, ColorSpec, WriteColor};
+
+pub fn print_size_optimization_results(results: &[OptimizationResult]) -> kompari::Result<()> {
+    if results.is_empty() {
+        println!("Nothing to optimize");
+        return Ok(());
+    }
+    let stdout = termcolor::StandardStream::stdout(termcolor::ColorChoice::Auto);
+    let mut stdout = stdout.lock();
+    let mut total_size = 0;
+    let mut total_diff = 0;
+    for result in results {
+        let diff = result.old_size - result.new_size;
+        stdout.set_color(ColorSpec::new().set_fg(None))?;
+        write!(stdout, "{}: ", result.path.display(),)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
+        write!(stdout, "{} ", format_size(result.new_size, DECIMAL))?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        writeln!(stdout, "(-{})", format_size(diff, DECIMAL))?;
+        total_size += result.new_size;
+        total_diff += diff;
+    }
+    stdout.set_color(ColorSpec::new().set_fg(None))?;
+    write!(stdout, "----------------------------\nTotal size: ",)?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
+    write!(stdout, "{} ", format_size(total_size, DECIMAL))?;
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+    writeln!(stdout, "(-{})", format_size(total_diff, DECIMAL))?;
+    Ok(())
+}

--- a/kompari-tasks/src/task.rs
+++ b/kompari-tasks/src/task.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::args::{Args, Command, DeadSnapshotArgs};
-use kompari::{list_image_dir, list_image_dir_names, DirDiffConfig};
+use crate::output::print_size_optimization_results;
+use kompari::{check_size_optimizations, list_image_dir, list_image_dir_names, DirDiffConfig};
 use kompari_html::{render_html_report, start_review_server, ReportConfig};
 use std::collections::BTreeSet;
 use std::ops::Deref;
@@ -68,6 +69,11 @@ impl Task {
                     self.actions.deref(),
                     ds_args,
                 )?;
+            }
+            Command::SizeCheck(sc_args) => {
+                let results =
+                    check_size_optimizations(self.diff_config.left_path(), sc_args.optimize)?;
+                print_size_optimization_results(&results)?;
             }
         }
         Ok(())

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -24,6 +24,7 @@ mod dirdiff;
 mod fsutils;
 mod imageutils;
 mod imgdiff;
+mod optimizations;
 
 /// The image type used throughout Kompari.
 pub type Image = image::RgbaImage;
@@ -52,3 +53,4 @@ pub use dirdiff::{DirDiff, DirDiffConfig, LeftRightError, PairResult};
 pub use fsutils::{list_image_dir, list_image_dir_names};
 pub use imageutils::{bless_image, image_to_png, load_image, optimize_png, SizeOptimizationLevel};
 pub use imgdiff::{compare_images, DiffImage, DiffImageMethod, ImageDifference};
+pub use optimizations::{check_size_optimizations, OptimizationResult};

--- a/kompari/src/optimizations.rs
+++ b/kompari/src/optimizations.rs
@@ -1,0 +1,34 @@
+use crate::{list_image_dir, optimize_png, SizeOptimizationLevel};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct OptimizationResult {
+    pub path: PathBuf,
+    pub old_size: usize,
+    pub new_size: usize,
+}
+
+pub fn check_size_optimizations(
+    dir_path: &Path,
+    optimize: bool,
+) -> crate::Result<Vec<OptimizationResult>> {
+    let mut results = Vec::new();
+    for path in list_image_dir(dir_path)? {
+        let old_data = std::fs::read(&path)?;
+        let old_size = old_data.len();
+        let new_data = optimize_png(old_data, SizeOptimizationLevel::High);
+        let new_size = new_data.len();
+        if old_size > new_size {
+            if optimize {
+                std::fs::write(&path, new_data)?;
+            }
+            results.push(OptimizationResult {
+                path,
+                old_size,
+                new_size,
+            });
+        }
+    }
+    results.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+    Ok(results)
+}

--- a/kompari/src/optimizations.rs
+++ b/kompari/src/optimizations.rs
@@ -1,3 +1,6 @@
+// Copyright 2025 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use crate::{list_image_dir, optimize_png, SizeOptimizationLevel};
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
This PR adds command "size-check" (to xtasks & CLI) that checks that snapshots are optimized. The demo usage on Parley:

![image](https://github.com/user-attachments/assets/99da966f-f222-4111-8a12-aed5d7794426)

Note: This PR also changes the CLI argument order to make more sense when just one path is needed. 