### PR TITLE
Disable pixelize for large images

### DIFF
--- a/kompari-html/src/pageconsts.rs
+++ b/kompari-html/src/pageconsts.rs
@@ -163,10 +163,9 @@ dialog {
 
 .zoomed-image {
     object-fit: contain;
-    image-rendering: -moz-crisp-edges;
-    image-rendering: -o-crisp-edges;
-    image-rendering: -webkit-optimize-contrast;
-    -ms-interpolation-mode: nearest-neighbor;
+}
+
+.zoomed-image-small {
     image-rendering: pixelated;
 }
 
@@ -276,9 +275,16 @@ input:checked + .slider:before {
 ";
 
 pub(crate) const JS_CODE: &str = "
-function openImageDialog(img) {
+function openImageDialog(img, pixelize) {
     const dialog = document.getElementById('imageDialog');
     const zoomedImg = document.getElementById('zoomedImage');
+
+    if (pixelize) {
+        zoomedImg.classList.add(\"zoomed-image-small\");
+    } else {
+        zoomedImg.classList.remove(\"zoomed-image-small\");
+    }
+
     zoomedImg.src = img.src;
     if (img.width < img.height) {
         zoomedImg.style.width = \"100%\";


### PR DESCRIPTION
This PR fixes a problem when large resolution images are shown in the report. So it does not affect Linebender usecases, because snapshots are usually small, but e.g. @Korf-tms uses Kompari for comparing A4 pdf renders so the problem is triggered.

The problem is that Kompari uses css flag "pixelize" in report when an image is zoomed. The idea is to avoid filtering for zoomed images so a user can see individual pixels. However when an image is bigger than the window and image size still has to be reduced, then "pixelize" reduces the quality of the output. 

The fix is simple, we disable "pixelize" for large images. We now define "large" image as an image that has both dimensions greater then 400.