### PR TITLE
Paralelization of dir diff computing and report generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
  "image",
  "log",
  "oxipng",
+ "rayon",
  "thiserror",
  "walkdir",
 ]
@@ -745,6 +746,7 @@ dependencies = [
  "imagesize",
  "kompari",
  "maud",
+ "rayon",
  "serde",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ oxipng = { version = "9.1", features = [
     "zopfli",
     "filetime",
 ], default-features = false }
+rayon = "1.10"  # Make sure that we are using the version as in oxipng
 log = "0.4"
 
 [workspace.lints]

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "image",
  "log",
  "oxipng",
+ "rayon",
  "thiserror",
  "walkdir",
 ]
@@ -673,6 +674,7 @@ dependencies = [
  "imagesize",
  "kompari",
  "maud",
+ "rayon",
  "serde",
  "tokio",
 ]

--- a/kompari-html/Cargo.toml
+++ b/kompari-html/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 
 [dependencies]
 kompari = { path = "../kompari", features = ["oxipng"] }
+rayon = { workspace = true }
 base64 = "0.22"
 chrono = "0.4"
 maud = "0.27"

--- a/kompari-tasks/Cargo.toml
+++ b/kompari-tasks/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 kompari = { path = "../kompari" }
 kompari-html = { path = "../kompari-html" }
 clap = { workspace = true }
+rayon = { workspace = true }
 termcolor = "1.4"
 humansize = "2.1"
 indicatif = "0.17"
-rayon = "1.10"                              # This should be same as in oxipng

--- a/kompari/Cargo.toml
+++ b/kompari/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 walkdir = "2.5"
 log = { workspace = true }
 oxipng = { workspace = true, optional = true }
+rayon = { workspace = true }
 
 [features]
 default = ["oxipng"]

--- a/kompari/src/dirdiff.rs
+++ b/kompari/src/dirdiff.rs
@@ -3,6 +3,8 @@
 
 use crate::imgdiff::{compare_images, ImageDifference};
 use crate::{list_image_dir_names, load_image};
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
@@ -40,7 +42,7 @@ impl DirDiffConfig {
             self.filter_name.as_deref(),
         )?;
         let diffs: Vec<_> = pairs
-            .into_iter()
+            .into_par_iter()
             .filter_map(|pair| {
                 let image_diff = compute_pair_diff(&pair);
                 if matches!(image_diff, Ok(ImageDifference::None)) {


### PR DESCRIPTION
This PR parallelizes directory diff computing and report generating.

Its add `rayon` dependency to `kompari` and `kompari-html`, but it was indirectly compiled anyway because of oxipng.

(I think that it starts to crystalize that current `kompari` create needs to be splitted into two `lightweight-kompari-for-usage-in-tests` and `common-utilities-for-postprocessing`, I will start a separate thread for this).