### PR TITLE
Added option --optimize-size

### DIFF
--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -104,13 +104,15 @@ fn main() -> kompari::Result<()> {
             let (diff_config, mut report_config) = make_diff_config(args.diff_args);
             let diff = diff_config.create_diff()?;
             report_config.set_embed_images(args.args.embed_images);
+            report_config.set_size_optimization(args.args.optimize_size.to_level());
             let report = render_html_report(&report_config, diff.results())?;
             let output = args.args.output.unwrap_or("report.html".into());
             std::fs::write(&output, report)?;
             println!("Report written into '{}'", output.display());
         }
         Args::Review(args) => {
-            let (diff_config, report_config) = make_diff_config(args.diff_args);
+            let (diff_config, mut report_config) = make_diff_config(args.diff_args);
+            report_config.set_size_optimization(args.args.optimize_size.to_level());
             start_review_server(&diff_config, &report_config, args.args.port)?
         }
         Args::SizeCheck(args) => {

--- a/kompari-html/src/lib.rs
+++ b/kompari-html/src/lib.rs
@@ -22,6 +22,7 @@ pub struct ReportConfig {
     right_title: String,
     embed_images: bool,
     is_review: bool,
+    size_optimization: SizeOptimizationLevel,
 }
 
 impl Default for ReportConfig {
@@ -31,6 +32,7 @@ impl Default for ReportConfig {
             right_title: "Right image".to_string(),
             embed_images: false,
             is_review: false,
+            size_optimization: SizeOptimizationLevel::None,
         }
     }
 }
@@ -45,10 +47,14 @@ impl ReportConfig {
     pub fn set_embed_images(&mut self, value: bool) {
         self.embed_images = value
     }
+    pub fn set_size_optimization(&mut self, value: SizeOptimizationLevel) {
+        self.size_optimization = value
+    }
     pub fn set_review(&mut self, value: bool) {
         self.is_review = value
     }
 }
 
+use kompari::SizeOptimizationLevel;
 pub use report::render_html_report;
 pub use review::start_review_server;

--- a/kompari-html/src/report.rs
+++ b/kompari-html/src/report.rs
@@ -5,7 +5,7 @@ use crate::pageconsts::{CSS_STYLE, ICON, JS_CODE};
 use crate::ReportConfig;
 use base64::prelude::*;
 use chrono::SubsecRound;
-use kompari::{ImageDifference, LeftRightError, PairResult, SizeOptimizationLevel};
+use kompari::{ImageDifference, LeftRightError, PairResult};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelRefIterator;
@@ -31,7 +31,7 @@ fn render_image(
         None => {
             let (path, size) = if config.embed_images {
                 let image_data =
-                    kompari::optimize_png(std::fs::read(path)?, SizeOptimizationLevel::Fast);
+                    kompari::optimize_png(std::fs::read(path)?, config.size_optimization);
                 (
                     embed_png_url(&image_data),
                     imagesize::blob_size(&image_data)
@@ -77,6 +77,7 @@ fn open_image_dialog(width: u32, height: u32) -> &'static str {
 }
 
 fn render_difference_image(
+    config: &ReportConfig,
     id: usize,
     difference: &Result<ImageDifference, LeftRightError>,
 ) -> Markup {
@@ -90,7 +91,7 @@ fn render_difference_image(
                             di.image.height(),
                             IMAGE_SIZE_LIMIT,
                         );
-                        let data = kompari::image_to_png(&di.image, SizeOptimizationLevel::Fast);
+                        let data = kompari::image_to_png(&di.image, config.size_optimization);
                         (w, h, data)
                    };
                    @let style = if idx == 0 { None } else { Some("display: none") };
@@ -200,7 +201,7 @@ fn render_pair_diff(
                     }
                     div class="image-box" {
                         h3 { "Difference"}
-                        (render_difference_image(id, &pair_diff.image_diff))
+                        (render_difference_image(config, id, &pair_diff.image_diff))
                     }
                 }
             }

--- a/kompari-tasks/src/args.rs
+++ b/kompari-tasks/src/args.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use kompari::SizeOptimizationLevel;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -20,6 +21,24 @@ pub enum Command {
     SizeCheck(SizeCheckArgs),
 }
 
+#[derive(ValueEnum, Debug, Clone, Copy)]
+#[clap(rename_all = "lowercase")]
+pub enum SizeOptimization {
+    None,
+    Fast,
+    High,
+}
+
+impl SizeOptimization {
+    pub fn to_level(&self) -> SizeOptimizationLevel {
+        match self {
+            SizeOptimization::None => SizeOptimizationLevel::None,
+            SizeOptimization::Fast => SizeOptimizationLevel::Fast,
+            SizeOptimization::High => SizeOptimizationLevel::High,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub struct ReportArgs {
     /// Output filename
@@ -29,6 +48,10 @@ pub struct ReportArgs {
     /// Embed images into the report
     #[arg(long, default_value_t = false)]
     pub embed_images: bool,
+
+    /// Optimize image sizes in HTML report
+    #[arg(long, default_value = "none")]
+    pub optimize_size: SizeOptimization,
 }
 
 #[derive(Parser, Debug)]
@@ -36,6 +59,10 @@ pub struct ReviewArgs {
     /// Port for web server
     #[arg(long, default_value_t = 7200)]
     pub port: u16,
+
+    /// Optimize image sizes in generated HTML
+    #[arg(long, default_value = "none")]
+    pub optimize_size: SizeOptimization,
 }
 
 #[derive(Parser, Debug)]

--- a/kompari-tasks/src/task.rs
+++ b/kompari-tasks/src/task.rs
@@ -47,6 +47,8 @@ impl Task {
                 if report_args.embed_images {
                     self.report_config.set_embed_images(true);
                 }
+                self.report_config
+                    .set_size_optimization(report_args.optimize_size.to_level());
                 let output: &Path = report_args
                     .output
                     .as_deref()
@@ -57,6 +59,8 @@ impl Task {
                 println!("Report written into '{}'", output.display());
             }
             Command::Review(args) => {
+                self.report_config
+                    .set_size_optimization(args.optimize_size.to_level());
                 start_review_server(&self.diff_config, &self.report_config, args.port)?
             }
             Command::Clean => {

--- a/kompari/src/imageutils.rs
+++ b/kompari/src/imageutils.rs
@@ -5,7 +5,7 @@ use crate::Image;
 use std::io::Cursor;
 use std::path::Path;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum SizeOptimizationLevel {
     None,
     Fast,


### PR DESCRIPTION
After recent changes, kompari report was optimized with oxipng. On my larger testing datasets it may takes tens of seconds to get the report (and situation is getting worse when more image diff variants are included). If the size optimization is disabled, you will get the report usually like 10x faster while making the file about 3x larger. 

This PR:
* disables optimization by default for generating HTML report (when test is interactively blessed, it is still optimized).
* Introduces option for report/review command: `--optimize-size=none/fast/hight` that allows to reenable the size optimization in generated HTML.