### PR TITLE
Remove dependency on `image` in Kompari

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # If the compilation fails, then the version specified here needs to be bumped up to reality.
   # Be sure to also update the rust-version property in the workspace Cargo.toml file,
   # the Unreleased section of CHANGELOG.md, plus all the README.md files of the affected packages.
-  RUST_MIN_VER: "1.78"
+  RUST_MIN_VER: "1.82"
   # List of packages that can not target Wasm.
   NO_WASM_PKGS: "--exclude kompari-cli --exclude kompari-html --exclude kompari-tasks"
   # List of packages that will be checked with the minimum supported Rust version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You can find its changes [documented below](#010---2024-12-31).
 
 ## [Unreleased]
 
-This release has an [MSRV][] of 1.78.
+This release has an [MSRV][] of 1.82.
 
 - Initial release.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,15 +222,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "bytes"
@@ -306,6 +300,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c387f6cef110ee8eaf12fca5586d3d303c07c594f4a5f02c768b6470b70dbd"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "colorchoice"
@@ -649,18 +652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,9 +707,11 @@ dependencies = [
 name = "kompari"
 version = "0.1.0"
 dependencies = [
- "image",
+ "bytemuck",
+ "color",
  "log",
  "oxipng",
+ "png",
  "rayon",
  "thiserror",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/linebender/kompari"
 
 [workspace.dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }
+png = "0.17.16"
 thiserror = { version = "2" }
 clap = { version = "4.5", features = ["derive"] }
 oxipng = { version = "9.1", features = [
@@ -20,7 +21,7 @@ oxipng = { version = "9.1", features = [
     "zopfli",
     "filetime",
 ], default-features = false }
-rayon = "1.10"  # Make sure that we are using the version as in oxipng
+rayon = "1.10" # Make sure that we are using the version as in oxipng
 log = "0.4"
 
 [workspace.lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files,
 # and with the MSRV in the Unreleased section of CHANGELOG.md.
-rust-version = "1.78"
+rust-version = "1.82"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/kompari"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/kompari"
 
 [workspace.dependencies]
-image = { version = "0.25", default-features = false, features = ["png"] }
 png = "0.17.16"
 thiserror = { version = "2" }
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ cargo run --release review <left/image_dir> <right/image_dir>
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of Kompari has been verified to compile with **Rust 1.78** and later.
+This version of Kompari has been verified to compile with **Rust 1.82** and later.
 
 Future versions of Kompari might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.

--- a/kompari-html/src/report.rs
+++ b/kompari-html/src/report.rs
@@ -5,7 +5,7 @@ use crate::pageconsts::{CSS_STYLE, ICON, JS_CODE};
 use crate::ReportConfig;
 use base64::prelude::*;
 use chrono::SubsecRound;
-use kompari::image::Rgba;
+use kompari::color::Rgba8;
 use kompari::{ImageDifference, LeftRightError, PairResult};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use rayon::iter::IndexedParallelIterator;
@@ -88,8 +88,8 @@ fn render_difference_image(
                 @for (idx, di) in diff_images.iter().enumerate() {
                     @let (w, h, data) = {
                         let (w, h) = html_size(
-                            di.image.width(),
-                            di.image.height(),
+                            di.image.width,
+                            di.image.height,
                             IMAGE_SIZE_LIMIT,
                         );
                         let data = kompari::image_to_png(&di.image, config.size_optimization);
@@ -101,7 +101,7 @@ fn render_difference_image(
                        class="zoom"
                        src=(embed_png_url(&data))
                        width=[w] height=[h]
-                       onclick=(open_image_dialog(di.image.width(), di.image.height()));
+                       onclick=(open_image_dialog(di.image.width, di.image.height));
                 }
                 div class="tabs" {
                     @for (idx, img) in diff_images.iter().enumerate() {
@@ -120,8 +120,8 @@ fn render_difference_image(
     }
 }
 
-fn rgba_to_hex(rgba: Rgba<u8>) -> String {
-    let [r, g, b, a] = rgba.0;
+fn rgba_to_hex(rgba: Rgba8) -> String {
+    let Rgba8 { r, g, b, a } = rgba;
     if a == u8::MAX {
         format!("#{:02X}{:02X}{:02X}", r, g, b)
     } else {
@@ -129,7 +129,7 @@ fn rgba_to_hex(rgba: Rgba<u8>) -> String {
     }
 }
 
-fn render_stat_color(label: &str, value_type: &str, color: Rgba<u8>) -> Markup {
+fn render_stat_color(label: &str, value_type: &str, color: Rgba8) -> Markup {
     let hex = rgba_to_hex(color);
     html! {
         div .stat-item {

--- a/kompari-html/src/report.rs
+++ b/kompari-html/src/report.rs
@@ -36,13 +36,12 @@ fn render_image(
                 (
                     embed_png_url(&image_data),
                     imagesize::blob_size(&image_data)
-                        .map_err(|e| kompari::Error::GenericError(e.to_string()))?,
+                        .map_err(|e| kompari::Error::GenericError(Box::new(e)))?,
                 )
             } else {
                 (
                     path.display().to_string(),
-                    imagesize::size(path)
-                        .map_err(|e| kompari::Error::GenericError(e.to_string()))?,
+                    imagesize::size(path).map_err(|e| kompari::Error::GenericError(Box::new(e)))?,
                 )
             };
             let (w, h) = html_size(size.width as u32, size.height as u32, IMAGE_SIZE_LIMIT);

--- a/kompari/Cargo.toml
+++ b/kompari/Cargo.toml
@@ -21,12 +21,14 @@ targets = []
 
 [dependencies]
 # For the bulk of Kompari's functionality
-image = { workspace = true }
+color = { version = "0.2.3", features = ["bytemuck"] }
+png = { workspace = true }
 thiserror = { workspace = true }
 walkdir = "2.5"
 log = { workspace = true }
 oxipng = { workspace = true, optional = true }
 rayon = { workspace = true }
+bytemuck = { default-features = false, version = "1.22.0" }
 
 [features]
 default = ["oxipng"]

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -16,7 +16,9 @@
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-pub use image;
+pub use color;
+pub use png;
+
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -24,9 +26,12 @@ mod dirdiff;
 mod fsutils;
 mod imageutils;
 mod imgdiff;
+mod minimal_image;
+
+pub use crate::minimal_image::MinImage;
 
 /// The image type used throughout Kompari.
-pub type Image = image::RgbaImage;
+// pub type Image = image::RgbaImage;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -38,9 +43,6 @@ pub enum Error {
 
     #[error("File not found: `{0}`")]
     FileNotFound(PathBuf),
-
-    #[error("Image error")]
-    ImageError(#[from] image::ImageError),
 
     #[error("Error `{0}`")]
     GenericError(String),

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -44,8 +44,20 @@ pub enum Error {
     #[error("File not found: `{0}`")]
     FileNotFound(PathBuf),
 
+    #[error("An input png image was grayscale.")]
+    ImageNotRgba,
+    #[error("Image is unresolved LFS file. Maybe you need to install lfs - https://git-lfs.com/?")]
+    // TODO: My plan is that Kompari Tasks will catch this error at a higher level, and give a more detailed message for it
+    // This avoids spamming a really long message for each test.
+    LFSMissing,
+
     #[error("Error `{0}`")]
-    GenericError(String),
+    GenericError(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error(transparent)]
+    PngDecoding(#[from] png::DecodingError),
+    #[error(transparent)]
+    PngEncoding(#[from] png::EncodingError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/kompari/src/minimal_image.rs
+++ b/kompari/src/minimal_image.rs
@@ -1,0 +1,113 @@
+// Copyright 2024 the Kompari Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::io;
+
+use color::Rgba8;
+use png::Transformations;
+
+/// A minimally defined Image type on top of the [`color`] crate.
+///
+/// This is used inside Kompari as the [Image crate](https://github.com/image-rs/image)
+/// (which we believe to be the main competitor) has a very significant compile time cost.
+pub struct MinImage {
+    /// The width of the image, in pixels.
+    pub width: u32,
+    /// The height of the image, in pixels.
+    pub height: u32,
+    /// The data of the image, stored in row-major order
+    /// (that is, the first `width` elements are the first row)
+    pub data: Vec<Rgba8>,
+}
+
+impl std::fmt::Debug for MinImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MinImage")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("data", &format_args!("{} pixels", self.data.len()))
+            .finish()
+    }
+}
+
+impl MinImage {
+    /// Utility to decode from the png data provided by reader into a `MinImage`.
+    ///
+    /// This method assumes that the image is not grayscale.
+    pub fn decode_from_png(mut reader: impl io::Read + io::Seek) -> Result<Self, crate::Error> {
+        let start_location = reader.stream_position();
+        let error = match Self::png_decode_internal(&mut reader) {
+            Ok(ret) => return Ok(ret),
+            Err(error) => error,
+        };
+        // If it wasn't a png file, see if it was actually (probably) an LFS file.
+        if let Ok(pos) = start_location {
+            if reader.seek(io::SeekFrom::Start(pos)).is_err() {
+                return Err(error);
+            }
+            match try_detect_lfs(reader) {
+                // If the file was actually an LFS file, return the more
+                // specific error for that case
+                Ok(Some(e)) => Err(e),
+                // Otherwise, return the error we got from trying to decode as png.
+                _ => Err(error),
+            }
+        } else {
+            Err(error)
+        }
+    }
+
+    pub fn encode_to_png(&self, write: impl io::Write) -> Result<(), crate::Error> {
+        let mut encoder = png::Encoder::new(write, self.width, self.height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| crate::Error::GenericError(format!("Error encoding PNG: {e}")))?;
+        writer
+            .write_image_data(bytemuck::cast_slice(&self.data))
+            .map_err(|e| crate::Error::GenericError(format!("Error encoding PNG: {e}")))?;
+        Ok(())
+    }
+
+    fn png_decode_internal(source: impl io::Read + io::Seek) -> Result<Self, crate::Error> {
+        let mut decoder = png::Decoder::new(source);
+        decoder
+            // We treat all images as 8 bit per channel, for simplicity.
+            .set_transformations(Transformations::normalize_to_color8() | Transformations::ALPHA);
+        let mut reader = decoder.read_info().unwrap_or_else(|e| todo!("Handle {e}"));
+        let (png::ColorType::Rgba, png::BitDepth::Eight) = reader.output_color_type() else {
+            todo!("Give a proper error type for image not being RGBA8");
+        };
+
+        let mut buf = Vec::<Rgba8>::with_capacity(reader.output_buffer_size() / 4);
+        let data = bytemuck::cast_slice_mut(&mut buf);
+        let (width, height) = reader.info().size();
+        reader
+            .next_frame(data)
+            .unwrap_or_else(|e| todo!("Handle {e}"));
+        Ok(Self {
+            width,
+            height,
+            data: buf,
+        })
+    }
+}
+
+const LFS_HEADER: &[u8] = b"version https://git-lfs.github.com/spec/v1\n";
+
+fn try_detect_lfs(
+    mut reader: impl io::Read + io::Seek,
+) -> Result<Option<crate::Error>, crate::Error> {
+    let mut buf = vec![0; LFS_HEADER.len()];
+    reader.read_exact(&mut buf)?;
+    if buf == LFS_HEADER {
+        // TODO: More advanced formatting.
+        Ok(Some(crate::Error::GenericError(
+            "Image is unresolved LFS file. Maybe you need to install lfs - https://git-lfs.com/?"
+                .into(),
+        )))
+    } else {
+        Ok(None)
+    }
+}

--- a/kompari/src/minimal_image.rs
+++ b/kompari/src/minimal_image.rs
@@ -76,7 +76,15 @@ impl MinImage {
             return Err(crate::Error::ImageNotRgba);
         };
 
-        let mut buf = Vec::<Rgba8>::with_capacity(reader.output_buffer_size() / 4);
+        let mut buf = vec![
+            Rgba8 {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0
+            };
+            reader.output_buffer_size() / 4
+        ];
         let data = bytemuck::cast_slice_mut(&mut buf);
         let (width, height) = reader.info().size();
         reader.next_frame(data)?;


### PR DESCRIPTION
This is for compile time and binary size reasons; it also helps to avoid some insane situations where image could read snapshots encoded in the wrong format.

This PR cut debug build time of just Kompari to 2.3s from 2.6s. When we also remove `thiserror` (which I intend to do), that will be cut down significantly further; thiserror is hiding the impact of image.