### PR TITLE
Background detection

### DIFF
--- a/kompari-html/src/pageconsts.rs
+++ b/kompari-html/src/pageconsts.rs
@@ -272,6 +272,15 @@ input:checked + .slider:before {
     color: #666;
     font-size: 80%;
 }
+
+.color-square {
+    margin-left: 10px;
+    margin-right: 10px;
+    display: inline-block;
+    width: 10px;
+    width: 10px;
+    height: 10px;
+    border: 2px solid black;
 ";
 
 pub(crate) const JS_CODE: &str = "


### PR DESCRIPTION
Implemented #37.

Kompari tries to detect background, when it happens it shows the background color in stats and compute percentages from non-bg pixels.

(This shows an test where all pixels are slightly brighter)
<img width="2354" height="802" alt="image" src="https://github.com/user-attachments/assets/ee69787e-6675-45bd-b1c0-599fb2c68cc7" />
