### PR TITLE
Fix error message

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder-lite"
@@ -278,6 +278,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7f99105610438d4b3ee7ae8e453c2990e325c806a14d71e8ea937d584c5289"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "colorchoice"
@@ -656,9 +665,11 @@ dependencies = [
 name = "kompari"
 version = "0.1.0"
 dependencies = [
- "image",
+ "bytemuck",
+ "color",
  "log",
  "oxipng",
+ "png",
  "rayon",
  "thiserror",
  "walkdir",
@@ -874,9 +885,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "png"
-version = "0.17.15"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",

--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -10,7 +10,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use clap::Parser;
 use kompari::DirDiffConfig;

--- a/kompari-html/src/lib.rs
+++ b/kompari-html/src/lib.rs
@@ -10,7 +10,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod pageconsts;
 mod report;

--- a/kompari-tasks/src/lib.rs
+++ b/kompari-tasks/src/lib.rs
@@ -10,7 +10,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod args;
 mod optimizations;

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("IO error")]
     IoError(#[from] std::io::Error),
 
-    #[error("Path is a directory: `{0}`")]
+    #[error("Path is not a directory: `{0}`")]
     NotDirectory(PathBuf),
 
     #[error("File not found: `{0}`")]

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -14,7 +14,7 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use color;
 pub use png;


### PR DESCRIPTION
Fixes #39 + updates Cargo.lock that was not updated after removal of `image` dependency.