### PR TITLE
Disable grayscale in oxipng

### DIFF
--- a/kompari/src/imageutils.rs
+++ b/kompari/src/imageutils.rs
@@ -28,7 +28,9 @@ pub fn optimize_png(data: Vec<u8>, opt_level: SizeOptimizationLevel) -> Vec<u8> 
         SizeOptimizationLevel::Fast => 2,
         SizeOptimizationLevel::High => 5,
     };
-    oxipng::optimize_from_memory(&data[..], &oxipng::Options::from_preset(preset))
+    let mut options = oxipng::Options::from_preset(preset);
+    options.grayscale_reduction = false;
+    oxipng::optimize_from_memory(&data[..], &options)
         .inspect_err(|e| log::warn!("PNG optimization failed: {}", e))
         .unwrap_or(data)
 }


### PR DESCRIPTION
This fixes the problem that the current Kompari is not able to load its own optimized image when the image was grayscale.

After #36, kompari is not able to load gray scale PNGs, while oxipng default configuration convert image to grayscale when possible. This PR disables this oxipng optimization.