### PR TITLE
Allow per-pixel distances up to a tolerance

### DIFF
--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -65,6 +65,11 @@ struct DiffArgs {
     /// Filter filenames by name
     #[arg(long)]
     filter: Option<String>,
+
+    /// Maximum per-pixel color distance to consider as matching (set to `0` to require exact
+    /// matches)
+    #[arg(long, default_value_t = 0)]
+    pixel_distance_tolerance: u8,
 }
 
 #[derive(Parser, Debug)]
@@ -88,6 +93,7 @@ fn make_diff_config(args: DiffArgs) -> (DirDiffConfig, ReportConfig) {
     diff_config.set_ignore_left_missing(args.ignore_left_missing);
     diff_config.set_ignore_right_missing(args.ignore_right_missing);
     diff_config.set_filter_name(args.filter);
+    diff_config.set_pixel_distance_tolerance(args.pixel_distance_tolerance);
 
     let mut report_config = ReportConfig::default();
     report_config.set_left_title(args.left_title);

--- a/kompari/src/dirdiff.rs
+++ b/kompari/src/dirdiff.rs
@@ -14,6 +14,13 @@ pub struct DirDiffConfig {
     ignore_left_missing: bool,
     ignore_right_missing: bool,
     filter_name: Option<String>,
+
+    /// The per-pixel distance that we tolerate. Only if the distance is greater than this will the
+    /// pixel be counted as being different.
+    ///
+    /// Because the pixel distance is the max per-channel distance, this is a per-channel
+    /// tolerance.
+    pixel_distance_tolerance: u8,
 }
 
 impl DirDiffConfig {
@@ -24,6 +31,7 @@ impl DirDiffConfig {
             ignore_left_missing: false,
             ignore_right_missing: false,
             filter_name: None,
+            pixel_distance_tolerance: 0,
         }
     }
 
@@ -41,10 +49,11 @@ impl DirDiffConfig {
             &self.right_path,
             self.filter_name.as_deref(),
         )?;
+        let tolerance = self.pixel_distance_tolerance;
         let diffs: Vec<_> = pairs
             .into_par_iter()
             .filter_map(|pair| {
-                let image_diff = compute_pair_diff(&pair);
+                let image_diff = compute_pair_diff(&pair, tolerance);
                 if matches!(image_diff, Ok(ImageDifference::None)) {
                     return None;
                 }
@@ -79,6 +88,10 @@ impl DirDiffConfig {
 
     pub fn set_filter_name(&mut self, value: Option<String>) {
         self.filter_name = value;
+    }
+
+    pub fn set_pixel_distance_tolerance(&mut self, value: u8) {
+        self.pixel_distance_tolerance = value;
     }
 }
 
@@ -188,7 +201,10 @@ pub(crate) fn pairs_from_paths(
         .collect())
 }
 
-fn compute_pair_diff(pair: &Pair) -> Result<ImageDifference, LeftRightError> {
+fn compute_pair_diff(
+    pair: &Pair,
+    pixel_distance_tolerance: u8,
+) -> Result<ImageDifference, LeftRightError> {
     let left = load_image(&pair.left);
     let right = load_image(&pair.right);
     let (left_image, right_image) = match (left, right) {
@@ -197,5 +213,9 @@ fn compute_pair_diff(pair: &Pair) -> Result<ImageDifference, LeftRightError> {
         (Ok(_), Err(e)) => return Err(LeftRightError::Right(e)),
         (Err(e1), Err(e2)) => return Err(LeftRightError::Both(Box::new((e1, e2)))),
     };
-    Ok(compare_images(&left_image, &right_image))
+    Ok(compare_images(
+        &left_image,
+        &right_image,
+        pixel_distance_tolerance,
+    ))
 }

--- a/kompari/src/imgdiff.rs
+++ b/kompari/src/imgdiff.rs
@@ -185,7 +185,7 @@ pub fn compare_images(
             .iter()
             .zip(&right.data)
             .map(|(pl, pr)| {
-                if pl == pr {
+                if pixel_distance(*pl, *pr) <= tolerance {
                     if *pl == bg {
                         n_pixels -= 1;
                     };

--- a/kompari/src/imgdiff.rs
+++ b/kompari/src/imgdiff.rs
@@ -72,7 +72,11 @@ impl Debug for ImageDifference {
     }
 }
 
-fn compute_rg_diff_image(left: &MinImage, right: &MinImage) -> (MinImage, u64) {
+fn compute_rg_diff_image(
+    left: &MinImage,
+    right: &MinImage,
+    pixel_distance_tolerance: u8,
+) -> (MinImage, u64) {
     let mut distance_sum = 0;
     let diff_image_data = left
         .data
@@ -80,7 +84,10 @@ fn compute_rg_diff_image(left: &MinImage, right: &MinImage) -> (MinImage, u64) {
         .zip(&right.data)
         .map(|(&p1, &p2)| {
             let (diff_min, diff_max) = pixel_min_max_distance(p1, p2);
-            distance_sum += diff_max.max(diff_min) as u64;
+            let max_dist = diff_max.max(diff_min);
+            if max_dist > pixel_distance_tolerance {
+                distance_sum += max_dist as u64;
+            }
             if diff_min > diff_max {
                 Rgba8 {
                     r: diff_min,
@@ -106,14 +113,18 @@ fn compute_rg_diff_image(left: &MinImage, right: &MinImage) -> (MinImage, u64) {
     (image, distance_sum)
 }
 
-fn compute_overlay_diff_image(left: &MinImage, right: &MinImage) -> MinImage {
+fn compute_overlay_diff_image(
+    left: &MinImage,
+    right: &MinImage,
+    pixel_distance_tolerance: u8,
+) -> MinImage {
     let diff_image_data = left
         .data
         .iter()
         .zip(&right.data)
         .map(|(&p1, &p2)| {
             let distance = pixel_distance(p1, p2);
-            if distance > 0 {
+            if distance > pixel_distance_tolerance as u64 {
                 p2
             } else {
                 // Opaque pixels with no difference are made more transparent; we hide sufficiently translucenst ones
@@ -147,8 +158,15 @@ fn detect_background(image: &MinImage) -> Option<Rgba8> {
         .map(|(packed, _)| Rgba8::from_u32(packed))
 }
 
-/// Find differences between two images
-pub fn compare_images(left: &MinImage, right: &MinImage) -> ImageDifference {
+/// Find differences between two images.
+///
+/// Pixels with a distance of at most `pixel_distance_tolerance` are considered matching. Use `0`
+/// for exact comparison.
+pub fn compare_images(
+    left: &MinImage,
+    right: &MinImage,
+    pixel_distance_tolerance: u8,
+) -> ImageDifference {
     if left.width != right.width || left.height != right.height {
         return ImageDifference::SizeMismatch {
             left_size: (left.width, left.height),
@@ -161,6 +179,7 @@ pub fn compare_images(left: &MinImage, right: &MinImage) -> ImageDifference {
     let background = detect_background(left)
         .and_then(|bg1| detect_background(right).and_then(|bg2| (bg1 == bg2).then_some(bg1)));
 
+    let tolerance = pixel_distance_tolerance as u64;
     let n_different_pixels: u64 = if let Some(bg) = background {
         left.data
             .iter()
@@ -180,15 +199,22 @@ pub fn compare_images(left: &MinImage, right: &MinImage) -> ImageDifference {
         left.data
             .iter()
             .zip(&right.data)
-            .map(|(pl, pr)| if pl == pr { 0 } else { 1 })
+            .map(|(pl, pr)| {
+                if pixel_distance(*pl, *pr) <= tolerance {
+                    0
+                } else {
+                    1
+                }
+            })
             .sum()
     };
     if n_different_pixels == 0 {
         return ImageDifference::None;
     }
 
-    let (rg_diff_image, distance_sum) = compute_rg_diff_image(left, right);
-    let overlay_diff_image = compute_overlay_diff_image(left, right);
+    let (rg_diff_image, distance_sum) =
+        compute_rg_diff_image(left, right, pixel_distance_tolerance);
+    let overlay_diff_image = compute_overlay_diff_image(left, right, pixel_distance_tolerance);
     ImageDifference::Content {
         n_pixels,
         n_different_pixels,

--- a/kompari/tests/compare.rs
+++ b/kompari/tests/compare.rs
@@ -1,7 +1,8 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use kompari::{DirDiffConfig, ImageDifference, LeftRightError};
+use kompari::color::Rgba8;
+use kompari::{compare_images, DirDiffConfig, ImageDifference, LeftRightError, MinImage};
 use std::path::Path;
 
 fn create_test_diff_config() -> DirDiffConfig {
@@ -104,4 +105,34 @@ pub(crate) fn test_ignore_right_missing() {
             "size_error.png"
         ]
     );
+}
+
+#[test]
+fn test_pixel_distance_tolerance() {
+    let px = |r| Rgba8 {
+        r,
+        g: 0,
+        b: 0,
+        a: 255,
+    };
+    let left = MinImage {
+        width: 2,
+        height: 2,
+        data: vec![px(100), px(100), px(100), px(100)],
+    };
+    let right = MinImage {
+        width: 2,
+        height: 2,
+        // distances: 0, 1, 2, 3
+        data: vec![px(100), px(101), px(102), px(103)],
+    };
+    // With tolerance=2, only the pixel with distance 3 is different.
+    let diff = compare_images(&left, &right, 2);
+    assert!(matches!(
+        diff,
+        ImageDifference::Content {
+            n_different_pixels: 1,
+            ..
+        }
+    ));
 }


### PR DESCRIPTION
When comparing output of renderers, there will often be slight per-pixel differences. Say a "ground truth" color value is 115, simple rounding differences may cause the result to fall to 114 or 116.

This PR introduces a tolerance. Comparing two renderers, a tolerance of `2` is probably suitable.