### PR TITLE
Decode grayscale PNGs

### DIFF
--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -44,8 +44,6 @@ pub enum Error {
     #[error("File not found: `{0}`")]
     FileNotFound(PathBuf),
 
-    #[error("An input png image was grayscale.")]
-    ImageNotRgba,
     #[error("Image is unresolved LFS file. Maybe you need to install lfs - https://git-lfs.com/?")]
     // TODO: My plan is that Kompari Tasks will catch this error at a higher level, and give a more detailed message for it
     // This avoids spamming a really long message for each test.

--- a/kompari/src/minimal_image.rs
+++ b/kompari/src/minimal_image.rs
@@ -31,9 +31,7 @@ impl std::fmt::Debug for MinImage {
 }
 
 impl MinImage {
-    /// Utility to decode from the png data provided by reader into a `MinImage`.
-    ///
-    /// This method assumes that the image is not grayscale.
+    /// Utility to decode from the png data provided by `reader` into a [`MinImage`].
     pub fn decode_from_png(mut reader: impl io::Read + io::Seek) -> Result<Self, crate::Error> {
         let start_location = reader.stream_position();
         let error = match Self::png_decode_internal(&mut reader) {
@@ -72,27 +70,50 @@ impl MinImage {
             // We treat all images as 8 bit per channel, for simplicity.
             .set_transformations(Transformations::normalize_to_color8() | Transformations::ALPHA);
         let mut reader = decoder.read_info()?;
-        let (png::ColorType::Rgba, png::BitDepth::Eight) = reader.output_color_type() else {
-            return Err(crate::Error::ImageNotRgba);
+        let (color_type, png::BitDepth::Eight) = reader.output_color_type() else {
+            unreachable!("Images get normalized to 8-bit grayscale or color, so `png::BitDepth::Eight` should always match");
         };
-
-        let mut buf = vec![
-            Rgba8 {
-                r: 0,
-                g: 0,
-                b: 0,
-                a: 0
-            };
-            reader.output_buffer_size() / 4
-        ];
-        let data = bytemuck::cast_slice_mut(&mut buf);
         let (width, height) = reader.info().size();
-        reader.next_frame(data)?;
-        Ok(Self {
-            width,
-            height,
-            data: buf,
-        })
+
+        match color_type {
+            png::ColorType::Rgba => {
+                let mut buf = vec![
+                    Rgba8 {
+                        r: 0,
+                        g: 0,
+                        b: 0,
+                        a: 0,
+                    };
+                    reader.output_buffer_size() / 4
+                ];
+                let data = bytemuck::cast_slice_mut(&mut buf);
+                reader.next_frame(data)?;
+                Ok(Self {
+                    width,
+                    height,
+                    data: buf,
+                })
+            }
+            png::ColorType::GrayscaleAlpha => {
+                let mut raw = vec![0; reader.output_buffer_size()];
+                reader.next_frame(&mut raw)?;
+                let data = raw
+                    .chunks_exact(2)
+                    .map(|ga| Rgba8 {
+                        r: ga[0],
+                        g: ga[0],
+                        b: ga[0],
+                        a: ga[1],
+                    })
+                    .collect();
+                Ok(Self {
+                    width,
+                    height,
+                    data,
+                })
+            }
+            _ => unreachable!("Images get normalized to 8-bit grayscale or color, so the above two arms match all possible cases."),
+        }
     }
 }
 


### PR DESCRIPTION
https://github.com/linebender/kompari/pull/36 made it such that we can no longer load grayscale PNGs, and the later https://github.com/linebender/kompari/pull/42 made it such that we no longer produce them.

https://github.com/forest-rs/imaging has at least one grayscale snapshot produced by Kompari; being able to load grayscale images again reduces churn there.

This also removes an error variant, as the transformations should now capture all PNGs; i.e., I believe this makes all valid PNGs decodable by Kompari.