### PR TITLE
Update `color` to 0.3.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -303,9 +303,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "color"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c387f6cef110ee8eaf12fca5586d3d303c07c594f4a5f02c768b6470b70dbd"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
 dependencies = [
  "bytemuck",
 ]

--- a/kompari/Cargo.toml
+++ b/kompari/Cargo.toml
@@ -21,7 +21,7 @@ targets = []
 
 [dependencies]
 # For the bulk of Kompari's functionality
-color = { version = "0.2.3", features = ["bytemuck"] }
+color = { version = "0.3.2", features = ["bytemuck"] }
 png = { workspace = true }
 thiserror = { workspace = true }
 walkdir = "2.5"


### PR DESCRIPTION
This is a SemVer incompatible upgrade and changes are documented in [Color's `CHANGELOG.md`](https://github.com/linebender/color/blob/main/CHANGELOG.md).

It looks like we don't have to do any code changes in Kompari to land this.