### PR TITLE
Update `png` to 0.18.1 and `oxipng` to 10.1.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,12 +160,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -403,17 +397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
 ]
 
 [[package]]
@@ -686,9 +669,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -783,18 +766,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "plain",
- "redox_syscall",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -892,13 +863,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oxipng"
-version = "9.1.5"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c613f0f566526a647c7473f6a8556dbce22c91b13485ee4b4ec7ab648e4973"
+checksum = "efc4ea5566cd49b80c4b5e8eac2167d137d2ca3007ec8976d4cd9fe8b654ba2b"
 dependencies = [
  "bitvec",
  "crossbeam-channel",
- "filetime",
  "indexmap",
  "libdeflater",
  "log",
@@ -927,18 +897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1051,15 +1015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1041,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1451,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1464,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1474,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1487,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
 dependencies = [
  "unicode-ident",
 ]
@@ -1522,7 +1477,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1673,7 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,11 @@ imagesize = { version = "0.14.0", default-features = false, features = ["png"] }
 indicatif = "0.18.4"
 log = "0.4.29"
 maud = "0.27.0"
-oxipng = { version = "9.1.5", features = [
+oxipng = { version = "10.1.0", features = [
     "parallel",
     "zopfli",
-    "filetime",
 ], default-features = false }
-png = "0.17.16"
+png = "0.18.1"
 rayon = "1.11.0" # Make sure that we are using the version as in oxipng
 serde = "1.0.228"
 tempfile = "3.27.0"

--- a/kompari/src/imageutils.rs
+++ b/kompari/src/imageutils.rs
@@ -1,9 +1,11 @@
 // Copyright 2025 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::MinImage;
-use std::fs::File;
+use std::fs;
+use std::io::Cursor;
 use std::path::Path;
+
+use crate::MinImage;
 
 #[derive(Debug, Clone, Copy)]
 pub enum SizeOptimizationLevel {
@@ -17,8 +19,8 @@ pub fn load_image(path: &Path) -> crate::Result<MinImage> {
     if !path.is_file() {
         return Err(crate::Error::FileNotFound(path.to_path_buf()));
     }
-    let file = File::open(path)?;
-    MinImage::decode_from_png(file)
+    let bytes = fs::read(path)?;
+    MinImage::decode_from_png(Cursor::new(bytes))
 }
 
 #[cfg(feature = "oxipng")]
@@ -50,12 +52,12 @@ pub fn image_to_png(image: &MinImage, opt_level: SizeOptimizationLevel) -> Vec<u
 pub fn bless_image(source: &Path, target: &Path) -> crate::Result<()> {
     let image = load_image(source)?;
     let data = image_to_png(&image, SizeOptimizationLevel::High);
-    std::fs::write(target, data)?;
+    fs::write(target, data)?;
     Ok(())
 }
 
 #[cfg(not(feature = "oxipng"))]
 pub fn bless_image(source: &Path, target: &Path) -> crate::Result<()> {
-    std::fs::copy(source, target)?;
+    fs::copy(source, target)?;
     Ok(())
 }

--- a/kompari/src/minimal_image.rs
+++ b/kompari/src/minimal_image.rs
@@ -32,7 +32,7 @@ impl std::fmt::Debug for MinImage {
 
 impl MinImage {
     /// Utility to decode from the png data provided by reader into a `MinImage`.
-    pub fn decode_from_png(mut reader: impl io::Read + io::Seek) -> Result<Self, crate::Error> {
+    pub fn decode_from_png(mut reader: impl io::BufRead + io::Seek) -> Result<Self, crate::Error> {
         let start_location = reader.stream_position();
         let error = match Self::png_decode_internal(&mut reader) {
             Ok(ret) => return Ok(ret),
@@ -64,7 +64,7 @@ impl MinImage {
         Ok(())
     }
 
-    fn png_decode_internal(source: impl io::Read + io::Seek) -> Result<Self, crate::Error> {
+    fn png_decode_internal(source: impl io::BufRead + io::Seek) -> Result<Self, crate::Error> {
         let mut decoder = png::Decoder::new(source);
         decoder
             // We treat all images as 8 bit per channel, for simplicity.
@@ -83,7 +83,7 @@ impl MinImage {
                         b: 0,
                         a: 0
                     };
-                    reader.output_buffer_size() / 4
+                    reader.output_buffer_size().unwrap_or_default() / 4
                 ];
                 let data = bytemuck::cast_slice_mut(&mut buf);
                 reader.next_frame(data)?;
@@ -96,7 +96,7 @@ impl MinImage {
             png::ColorType::GrayscaleAlpha => {
                 // Grayscale images are decoded as [gray, alpha] pairs.
                 // Expand each to RGBA by copying gray into R, G, B.
-                let mut raw = vec![0_u8; reader.output_buffer_size()];
+                let mut raw = vec![0_u8; reader.output_buffer_size().unwrap_or_default()];
                 reader.next_frame(&mut raw)?;
                 let data = raw
                     .chunks_exact(2)


### PR DESCRIPTION
These both had breaking changes but luckily only minimal impact to Kompari code.

Both updates bring performance and correctness improvements.
* [`png` changelog](https://github.com/image-rs/image-png/blob/master/CHANGES.md)
* [`oxipng` changelog](https://github.com/oxipng/oxipng/blob/master/CHANGELOG.md)

The removal of the `filetime` feature of `oxipng` was not documented, but [the PR](https://github.com/oxipng/oxipng/pull/759) claims that the feature was removed because standard Rust now provides that functionality.