### PR TITLE
Update `imagesize` to 0.14.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,9 +643,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "imagesize"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.44"
 clap = { version = "4.6.0", features = ["derive"] }
 color = "0.3.2"
 humansize = "2.1.3"
-imagesize = "0.13.0"
+imagesize = { version = "0.14.0", default-features = false, features = ["png"] }
 indicatif = "0.17.11"
 log = "0.4.29"
 maud = "0.27.0"


### PR DESCRIPTION
Image formats are now feature gated in `imagesize`, which is great for us because we only care about 1 of the 22 supported formats.