### PR TITLE
Update Linebender lint set to v8.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,10 @@
+# LINEBENDER LINT SET - .clippy.toml - v1
+# See https://linebender.org/wiki/canonical-lints/
+
+# The default Clippy value is capped at 8 bytes, which was chosen to improve performance on 32-bit.
+# Given that we are building for the future and even low-end mobile phones have 64-bit CPUs,
+# it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
+# 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
+trivial-copy-size-limit = 16
+
+# END LINEBENDER LINT SET

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,11 @@
+# LINEBENDER RUSTFMT CONFIG - v1
+# Ensure lines end with \n even if the git configuration core.autocrlf is not set to true
+newline_style = "Unix"
+
+# `Foobar { foo, bar }` is more readable than `Foo { foo: foo, bar: bar }`
+use_field_init_shorthand = true
+
+# Commented out because it is still unstable, but works fine in practice.
+# imports_granularity = "Module"
+
+# END LINEBENDER RUSTFMT CONFIG

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,9 @@ tokio = "1.50.0"
 walkdir = "2.5.0"
 
 [workspace.lints]
-# This one may vary depending on the project.
 rust.unsafe_code = "forbid"
 
-# LINEBENDER LINT SET - Cargo.toml - v6
+# LINEBENDER LINT SET - Cargo.toml - v8
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"
@@ -55,21 +54,23 @@ rust.unsafe_op_in_unsafe_fn = "forbid"
 
 rust.elided_lifetimes_in_paths = "warn"
 rust.missing_debug_implementations = "warn"
-# rust.missing_docs = "warn"
 # TODO: We should document things
+# rust.missing_docs = "warn"
 rust.trivial_numeric_casts = "warn"
-rust.unexpected_cfgs = "warn"
 rust.unnameable_types = "warn"
 rust.unreachable_pub = "warn"
 rust.unused_import_braces = "warn"
 rust.unused_lifetimes = "warn"
 rust.unused_macro_rules = "warn"
+rust.unused_qualifications = "warn"
 
 clippy.too_many_arguments = "allow"
 
 clippy.allow_attributes_without_reason = "warn"
 clippy.cast_possible_truncation = "warn"
+clippy.cast_possible_wrap = "warn"
 clippy.collection_is_never_read = "warn"
+clippy.default_trait_access = "warn"
 clippy.dbg_macro = "warn"
 clippy.debug_assert_with_mut_call = "warn"
 clippy.doc_markdown = "warn"

--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// LINEBENDER LINT SET - lib.rs - v3
+// LINEBENDER LINT SET - lib.rs - v4
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/kompari-html/src/lib.rs
+++ b/kompari-html/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// LINEBENDER LINT SET - lib.rs - v3
+// LINEBENDER LINT SET - lib.rs - v4
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/kompari-tasks/src/lib.rs
+++ b/kompari-tasks/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// LINEBENDER LINT SET - lib.rs - v3
+// LINEBENDER LINT SET - lib.rs - v4
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate also includes utilities for creating image snapshot test suites.
 
-// LINEBENDER LINT SET - lib.rs - v3
+// LINEBENDER LINT SET - lib.rs - v4
 // See https://linebender.org/wiki/canonical-lints/
 // These lints shouldn't apply to examples or tests.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]


### PR DESCRIPTION
Updates Linebender [standard lints](https://linebender.org/wiki/canonical-lints/) to latest versions:
* `Cargo.toml` v8
* `lib.rs` v4
* [`.rustfmt.toml` v1](https://linebender.org/wiki/formatting-scheme/)
* `.clippy.toml` v1