### PR TITLE
Update Rust edition to 2024.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["kompari", "kompari-cli", "kompari-html", "kompari-tasks"]
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml, with the relevant README.md files,
 # and with the MSRV in the Unreleased section of CHANGELOG.md.
 rust-version = "1.85"

--- a/kompari-cli/src/main.rs
+++ b/kompari-cli/src/main.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use kompari::DirDiffConfig;
-use kompari_html::{render_html_report, start_review_server, ReportConfig};
+use kompari_html::{ReportConfig, render_html_report, start_review_server};
 use kompari_tasks::check_size_optimizations;
 use std::path::PathBuf;
 

--- a/kompari-html/src/report.rs
+++ b/kompari-html/src/report.rs
@@ -1,13 +1,13 @@
 // Copyright 2024 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::pageconsts::{CSS_STYLE, ICON, JS_CODE};
 use crate::ReportConfig;
+use crate::pageconsts::{CSS_STYLE, ICON, JS_CODE};
 use base64::prelude::*;
 use chrono::SubsecRound;
 use kompari::color::Rgba8;
 use kompari::{ImageDifference, LeftRightError, PairResult};
-use maud::{html, Markup, PreEscaped, DOCTYPE};
+use maud::{DOCTYPE, Markup, PreEscaped, html};
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;

--- a/kompari-html/src/review.rs
+++ b/kompari-html/src/review.rs
@@ -1,13 +1,13 @@
 // Copyright 2025 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::{render_html_report, ReportConfig};
+use crate::{ReportConfig, render_html_report};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse};
 use axum::routing::post;
-use axum::{routing::get, Json, Router};
-use kompari::{bless_image, DirDiffConfig};
+use axum::{Json, Router, routing::get};
+use kompari::{DirDiffConfig, bless_image};
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/kompari-tasks/src/lib.rs
+++ b/kompari-tasks/src/lib.rs
@@ -17,5 +17,5 @@ mod optimizations;
 mod task;
 
 pub use args::Args;
-pub use optimizations::{check_size_optimizations, OptimizationResult};
+pub use optimizations::{OptimizationResult, check_size_optimizations};
 pub use task::{Actions, Task};

--- a/kompari-tasks/src/optimizations.rs
+++ b/kompari-tasks/src/optimizations.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::args::SizeCheckArgs;
-use humansize::{format_size, DECIMAL};
-use kompari::{list_image_dir, optimize_png, SizeOptimizationLevel};
+use humansize::{DECIMAL, format_size};
+use kompari::{SizeOptimizationLevel, list_image_dir, optimize_png};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::cmp::min;
 use std::io::Write;

--- a/kompari-tasks/src/task.rs
+++ b/kompari-tasks/src/task.rs
@@ -3,8 +3,8 @@
 
 use crate::args::{Args, Command, DeadSnapshotArgs};
 use crate::check_size_optimizations;
-use kompari::{list_image_dir, list_image_dir_names, DirDiffConfig};
-use kompari_html::{render_html_report, start_review_server, ReportConfig};
+use kompari::{DirDiffConfig, list_image_dir, list_image_dir_names};
+use kompari_html::{ReportConfig, render_html_report, start_review_server};
 use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};

--- a/kompari/src/dirdiff.rs
+++ b/kompari/src/dirdiff.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the Kompari Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::imgdiff::{compare_images, ImageDifference};
+use crate::imgdiff::{ImageDifference, compare_images};
 use crate::{list_image_dir_names, load_image};
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;

--- a/kompari/src/lib.rs
+++ b/kompari/src/lib.rs
@@ -62,5 +62,5 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 pub use dirdiff::{DirDiff, DirDiffConfig, LeftRightError, PairResult};
 pub use fsutils::{list_image_dir, list_image_dir_names};
-pub use imageutils::{bless_image, image_to_png, load_image, optimize_png, SizeOptimizationLevel};
-pub use imgdiff::{compare_images, DiffImage, DiffImageMethod, ImageDifference};
+pub use imageutils::{SizeOptimizationLevel, bless_image, image_to_png, load_image, optimize_png};
+pub use imgdiff::{DiffImage, DiffImageMethod, ImageDifference, compare_images};

--- a/kompari/src/minimal_image.rs
+++ b/kompari/src/minimal_image.rs
@@ -72,7 +72,9 @@ impl MinImage {
         let mut reader = decoder.read_info()?;
         let (width, height) = reader.info().size();
         let (color_type, png::BitDepth::Eight) = reader.output_color_type() else {
-            unreachable!("Images get normalized to 8-bit grayscale or color, so `png::BitDepth::Eight` should always match");
+            unreachable!(
+                "Images get normalized to 8-bit grayscale or color, so `png::BitDepth::Eight` should always match"
+            );
         };
         match color_type {
             png::ColorType::Rgba => {
@@ -119,7 +121,9 @@ impl MinImage {
             //   - `Rgb` -> `Rgba`
             //   - `Grayscale` -> `GrayscaleAlpha`
             //   - `Indexed`-> `Rgba`
-            _ => unreachable!("Images get normalized to 8-bit grayscale or color, so the above two arms match all possible cases."),
+            _ => unreachable!(
+                "Images get normalized to 8-bit grayscale or color, so the above two arms match all possible cases."
+            ),
         }
     }
 }

--- a/kompari/tests/compare.rs
+++ b/kompari/tests/compare.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use kompari::color::Rgba8;
-use kompari::{compare_images, DirDiffConfig, ImageDifference, LeftRightError, MinImage};
+use kompari::{DirDiffConfig, ImageDifference, LeftRightError, MinImage, compare_images};
 use std::path::Path;
 
 fn create_test_diff_config() -> DirDiffConfig {


### PR DESCRIPTION
Now that the MSRV is 1.85 we can upgrade to the 2024 edition.

All the code changes in this PR are the result of `cargo fmt --all`.