### PR TITLE
Polish `Cargo.toml` files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/kompari"
 
 [workspace.dependencies]
-kompari = { version = "0.1.0", path = "kompari" }
-kompari-html = { version = "0.1.0", path = "kompari-html" }
-kompari-tasks = { version = "0.1.0", path = "kompari-tasks" }
+kompari = { version = "0.1.0", path = "kompari", default-features = false }
+kompari-html = { version = "0.1.0", path = "kompari-html", default-features = false }
+kompari-tasks = { version = "0.1.0", path = "kompari-tasks", default-features = false }
 
 assert_cmd = "2.2.0"
 axum = "0.8.8"
@@ -94,5 +94,6 @@ clippy.wildcard_dependencies = "warn"
 
 [profile.ci]
 inherits = "dev"
+debug = 0 # Don't compile debug info to reduce compilation artifact size for cache benefits.
 [profile.ci.package."*"]
 debug-assertions = true # Keep always on for dependencies for cache reuse.

--- a/kompari-cli/Cargo.toml
+++ b/kompari-cli/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "kompari-cli"
-description = "CLI for reporting tool of image differences for snapshot testing."
+description = "CLI for detecting and reporting image differences."
 keywords = ["image", "report", "diff", "tests"]
 categories = ["graphics", "multimedia::images", "development-tools::testing"]
-
 
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [dependencies]
 kompari = { workspace = true }
@@ -21,3 +26,7 @@ clap = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 tempfile = { workspace = true }
+
+# TODO: Enable lints
+#[lints]
+#workspace = true

--- a/kompari-html/Cargo.toml
+++ b/kompari-html/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "kompari-html"
-
-description = "HTML reports for image differences for snapshot testing."
+description = "HTML report generator for image differences."
 keywords = ["image", "report", "diff", "tests"]
 categories = ["graphics", "multimedia::images", "development-tools::testing"]
-
 
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [dependencies]
 kompari = { workspace = true, features = ["oxipng"] }
@@ -23,3 +27,7 @@ maud = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
+
+# TODO: Enable lints
+#[lints]
+#workspace = true

--- a/kompari-tasks/Cargo.toml
+++ b/kompari-tasks/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "kompari-tasks"
-
-description = "Supportive code for Xtasks based on Kompari"
+description = "Supportive code for Xtasks based on Kompari."
 keywords = ["image", "report", "diff", "tests"]
 categories = ["graphics", "multimedia::images", "development-tools::testing"]
-
 
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [dependencies]
 kompari = { workspace = true }
@@ -21,3 +25,7 @@ humansize = { workspace = true }
 indicatif = { workspace = true }
 rayon = { workspace = true }
 termcolor = { workspace = true }
+
+# TODO: Enable lints
+#[lints]
+#workspace = true

--- a/kompari/Cargo.toml
+++ b/kompari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kompari"
-description = "Snapshot test reporting CLI.."
+description = "Image diffing for testing and developer tools."
 keywords = ["image", "report", "diff", "tests"]
 categories = ["graphics", "multimedia::images", "development-tools::testing"]
 
@@ -10,14 +10,15 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[lints]
-workspace = true
-
 [package.metadata.docs.rs]
 all-features = true
 # There are no platform specific docs.
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
+
+[features]
+default = ["oxipng"]
+oxipng = ["dep:oxipng"]
 
 [dependencies]
 bytemuck = { workspace = true }
@@ -29,6 +30,5 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 walkdir = { workspace = true }
 
-[features]
-default = ["oxipng"]
-oxipng = ["dep:oxipng"]
+[lints]
+workspace = true


### PR DESCRIPTION
* Define the various workspace-local imports without default features.
* Don't compile debug info in CI to match latest Linebender standard.
* Compile docs only for one platform.
* Change order of TOML tables to match latest Linebender standard, where `features` come much earlier and `lints` later.
* Add dummy `lints` markers for all `Cargo.toml` files. Will be actually enabled in a separate PR to reduce noise here.
* Update package descriptions.